### PR TITLE
feat: add Dr. GRPO, LOOP, Magistral improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-.mypy_cache/
-.venv/
+.*/
+*.csv
+*.npz
+*.png
 uv.lock

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
 # microGRPO
 
-A tiny single-file implementation of Group Relative Policy Optimization (GRPO) as introduced by the [DeepSeekMath paper](https://arxiv.org/abs/2402.03300).
+A tiny single-file implementation of Group Relative Policy Optimization (GRPO) as introduced by the DeepSeekMath paper[^1][^2][^3].
 
-For further reading on GRPO, see [Yuge (Jimmy) Shi's blog post](https://yugeten.github.io/posts/2025/01/ppogrpo/) and [Nathan Lambert's RLHF book](https://rlhfbook.com/c/11-policy-gradients.html).
+🆕 microGRPO now implements the GRPO improvements introduced by Dr. GRPO[^4], Apple's LOOP[^5], and Mistral's Magistral[^6]:
+1. 💥 Remove per-group advantage normalization[^4]
+2. ⛳️ Leave-one-out advantage[^5] (LOOP only)
+3. 🔥 Eliminate KL divergence[^5]
+4. 🎢 Normalize loss[^5]
+5. 🏆 Add per-batch advantage normalization[^6] (Magistral only)
+6. 🚦 Relax trust region bounds[^5]
+7. 🌈 Eliminate non-diverse groups[^5]
+
+[^1]: [The DeepSeekMath paper](https://arxiv.org/abs/2402.03300)
+[^2]: [Yuge (Jimmy) Shi's blog post](https://yugeten.github.io/posts/2025/01/ppogrpo/)
+[^3]: [Nathan Lambert's RLHF book](https://rlhfbook.com/c/11-policy-gradients.html)
+[^4]: [The Dr. GRPO paper](https://arxiv.org/pdf/2503.20783)
+[^5]: [Apple's LOOP paper](https://arxiv.org/pdf/2502.01600)
+[^6]: [Mistral's Magistral paper](https://arxiv.org/pdf/2506.10910)
 
 ## Features
 
@@ -21,9 +35,9 @@ To start teaching a policy to play a simplified version of [Battleship](https://
 uv run microgrpo.py
 ```
 
-You should see that the policy learns to improve its average score from around 15% to about 49% over 2000 iterations:
+You should see that the policy learns to improve its average score from around 15% to about 50% over 2000 iterations:
 
-![Battleship policy trained with GRPO](https://github.com/user-attachments/assets/bfebd746-cd8f-4cba-b056-3224db4965fd)
+![Battleship policy trained with GRPO](https://github.com/user-attachments/assets/de464264-2d1c-43f2-9bc3-dcd9eea48c45)
 
 ## Background
 
@@ -33,25 +47,18 @@ The file is structured into five sections:
 
 1. 🕹️ Game (~50 lines): An implementation of the Battleship board game
 2. 🌍 Environment (~60 lines): The API with which an agent can interact with the game
-3. 🧠 Policy (~40 lines): A model that produces action probabilities given the observed environment state
-4. 🎯 GRPO (~90 lines): The GRPO objective function and training data generator
-5. ⚡ Train (~40 lines): The loop that collects training data and optimizes the GRPO objective with AdamW
+3. 🧠 Policy (~30 lines): A model that produces action probabilities given the observed environment state
+4. 🎯 GRPO (~80 lines): The GRPO objective function and training data generator
+5. ⚡ Train (~50 lines): The loop that collects training data and optimizes the GRPO objective with AdamW
 
 #### GRPO config
 
-Starting a training run requires defining a `GRPOConfig` with your choice of environment (here, `BattleshipEnv`), a function that evaluates the policy model given its parameters (here, `neural_battleship_policy`), and another function that evaluates a reference policy model that you don't want the policy to deviate too much from (here, `reference_battleship_policy`):
+Starting a training run only requires defining a `GRPOConfig` with your choice of environment (here, `BattleshipEnv`) and a function that evaluates the policy model given its parameters (here, `neural_battleship_policy`):
 
 ```python
-# Define the environment, the policy model to optimize, and a reference policy model.
-grpo_config = GRPOConfig(
-    environment=BattleshipEnv,
-    policy=neural_battleship_policy,
-    reference_policy=reference_battleship_policy,
-)
-
-# Initialize the policy model parameters.
-θ_init = neural_battleship_policy_init()
+# Define the environment and the policy model to optimize.
+grpo_config = GRPOConfig(environment=BattleshipEnv, policy=neural_battleship_policy)
 
 # Train the policy model by maximizing the GRPO objective with AdamW.
-θ_star, rewards_val = train_grpo(AdamWOptimizer(θ_init, learning_rate=3e-4), grpo_config)
+θ_star, rewards_val = train_grpo(θ_init := neural_battleship_policy_init(), grpo_config)
 ```

--- a/microgrpo.py
+++ b/microgrpo.py
@@ -228,10 +228,12 @@ def grpo_objective(policy_params: ParamsDict, group: Group, grpo_config: GRPOCon
             π_θ_t = grpo_config.policy(policy_params, observation)[action]
             ratio = π_θ_t / π_θ_t_old
             clipped_ratio = np.clip(π_θ_t / π_θ_t_old, 1 - grpo_config.ε, 1 + grpo_config.ε)
-            grpo += min(ratio * advantage, clipped_ratio * advantage) / len(actions)  # Advantage
-    grpo /= grpo_config.G
-    grpo = -grpo  # Flip the sign to turn the maximization problem into a minimization problem.
-    return grpo
+            grpo += min(ratio * advantage, clipped_ratio * advantage)  # Advantage
+    # Normalize the GRPO objective by the total number of steps in the group.
+    total_steps = sum(len(actions) for actions in group[2])
+    grpo /= max(1, total_steps)
+    # Flip the sign to turn the maximization problem into a minimization problem.
+    return -grpo
 
 
 # --- Train ---

--- a/microgrpo.py
+++ b/microgrpo.py
@@ -180,7 +180,8 @@ class GRPOConfig:
     environment: type[Environment]
     policy: PolicyFunction
 
-    ε: float = 0.9  # Policy ratio clip epsilon
+    ε_low: float = 0.9  # Policy ratio clip epsilon (low)
+    ε_high: float = 0.3  # Policy ratio clip epsilon (high)
     G: int = 16  # Number of trajectories per group
     B: int = 4  # Number of groups per mini-batch
     M: int = 2048  # Number of mini-batches to train on
@@ -234,7 +235,7 @@ def grpo_objective(policy_params: ParamsDict, groups: list[Group], grpo_config: 
             for obs, π_θ_t_old, action in zip(observations, actions_proba, actions):
                 π_θ_t = grpo_config.policy(policy_params, obs)[action]
                 ratio = π_θ_t / π_θ_t_old
-                clipped_ratio = np.clip(ratio, 1 - grpo_config.ε, 1 + grpo_config.ε)
+                clipped_ratio = np.clip(ratio, 1 - grpo_config.ε_low, 1 + grpo_config.ε_high)
                 grpo_group += min(ratio * A_norm, clipped_ratio * A_norm)
         # Normalize by the total number of steps in the group.
         total_steps = sum(len(actions) for actions in group[2])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,19 @@
 [project]
 name = "microGRPO"
-version = "0.0.0"
+version = "0.1.0"
 requires-python = ">=3.13"
+dependencies = [
+    "autograd~=1.8.0",
+    "numpy~=2.3.1",
+    "tqdm~=4.67.1",
+]
+
+[dependency-groups]
+dev = [
+    "matplotlib>=3.10.3",
+    "mypy>=1.16.1",
+    "ruff>=0.12.0",
+]
 
 [tool.mypy]
 strict = true
@@ -9,3 +21,11 @@ ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 150
+
+[tool.ruff.format]
+docstring-code-format = true
+skip-magic-trailing-comma = true
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = ["D", "N806", "PLC2401", "RET504"]


### PR DESCRIPTION
Changes:
- Add GRPO improvements introduced by [Dr. GRPO](https://arxiv.org/pdf/2503.20783), [Apple's LOOP](https://arxiv.org/pdf/2502.01600), and [Mistral's Magistral](https://arxiv.org/pdf/2506.10910).
- Reduce training to two lines of code: configuring GRPO with an env and policy, and starting the training loop given the config.
- Bump `autograd`, `numpy` and `tqdm` to their latest versions.
- Add development dependencies.
- Apply `ALL` ruff rules in linting.
- Update README to reflect the above changes.

Before this PR: ![Battleship policy trained with GRPO](https://github.com/user-attachments/assets/bfebd746-cd8f-4cba-b056-3224db4965fd)

After this PR: ![Battleship policy trained with GRPO](https://github.com/user-attachments/assets/de464264-2d1c-43f2-9bc3-dcd9eea48c45)